### PR TITLE
Bugfix: Empty command list error

### DIFF
--- a/Obvs.Tests/TestServiceBusClient.cs
+++ b/Obvs.Tests/TestServiceBusClient.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using Obvs.Types;
+using Xunit;
+
+namespace Obvs.Tests
+{
+    public class TestServiceBusClient
+    {
+        [Fact]
+        public async Task Given_NoEndpoints_When_SendAsyncMultiple_NoCommands_Assert_DoesNothing()
+        {
+            var serviceEndpointClients = Enumerable.Empty<IServiceEndpointClient<IMessage, ICommand, IEvent, IRequest, IResponse>>();
+            var serviceEndpoints = Enumerable.Empty<IServiceEndpoint<IMessage, ICommand, IEvent, IRequest, IResponse>>();
+            var sut = new ServiceBusClient<IMessage, ICommand, IEvent, IRequest, IResponse>(serviceEndpointClients, serviceEndpoints, new DefaultRequestCorrelationProvider());
+
+            var commands = new ICommand[0];
+
+            await sut.SendAsync(commands);
+        }
+
+        [Fact]
+        public async Task Given_NoEndpoints_When_SendAsyncMultiple_SingleCommand_Assert_ThrowsNoEndpointsConfigured()
+        {
+            var serviceEndpointClients = Enumerable.Empty<IServiceEndpointClient<IMessage, ICommand, IEvent, IRequest, IResponse>>();
+            var serviceEndpoints = Enumerable.Empty<IServiceEndpoint<IMessage, ICommand, IEvent, IRequest, IResponse>>();
+            var sut = new ServiceBusClient<IMessage, ICommand, IEvent, IRequest, IResponse>(serviceEndpointClients, serviceEndpoints, new DefaultRequestCorrelationProvider());
+
+            var commands = new[]{new TestServiceCommand1()};
+            
+            await Assert.ThrowsAsync<AggregateException>(() => sut.SendAsync(commands));
+        }
+
+        [Fact]
+        public async Task Given_NoEndpointsForCommand_When_SendAsyncMultiple_SingleCommand_Assert_ThrowsNoEndpointsConfigured()
+        {
+            var serviceEndpointClients = new IServiceEndpointClient<IMessage, ICommand, IEvent, IRequest, IResponse>[]{new FakeServiceEndpoint(typeof(TestServiceCommand2))};
+            var serviceEndpoints = Enumerable.Empty<IServiceEndpoint<IMessage, ICommand, IEvent, IRequest, IResponse>>();
+            var sut = new ServiceBusClient<IMessage, ICommand, IEvent, IRequest, IResponse>(serviceEndpointClients, serviceEndpoints, new DefaultRequestCorrelationProvider());
+
+            var commands = new[] { new TestServiceCommand1() };
+
+            await Assert.ThrowsAsync<AggregateException>(() => sut.SendAsync(commands));
+        }
+
+        [Fact]
+        public async Task Given_MultipleEndpointsForDifferentServices_When_SendAsyncMultiple_SingleCommand_Assert_CallsSendOnCorrectEndpointClient()
+        {
+            var signal = new Subject<Unit>();
+
+            var wrongEndpoint = new FakeServiceEndpoint(typeof(TestServiceCommand2));
+            var wrongCommands = wrongEndpoint.Messages.TakeUntil(signal).ToList().ToTask();
+            var correctEndpoint = new FakeServiceEndpoint(typeof(TestServiceCommand1));
+            var correctCommands = correctEndpoint.Messages.TakeUntil(signal).ToList().ToTask();
+
+            var serviceEndpointClients = new [] { wrongEndpoint, correctEndpoint };
+            var serviceEndpoints = Enumerable.Empty<IServiceEndpoint<IMessage, ICommand, IEvent, IRequest, IResponse>>();
+            var sut = new ServiceBusClient<IMessage, ICommand, IEvent, IRequest, IResponse>(serviceEndpointClients, serviceEndpoints, new DefaultRequestCorrelationProvider());
+
+            var cmd = new TestServiceCommand1();
+            var commands = new[] { cmd };
+
+            await sut.SendAsync(commands);
+
+            signal.OnNext(Unit.Default);
+
+            Assert.Empty(await wrongCommands);
+            var sentCommands = await correctCommands;
+            Assert.NotEmpty(sentCommands);
+            Assert.Contains(cmd, sentCommands);
+        }
+
+        [Fact]
+        public async Task Given_MultipleEndpointsForSameServices_When_SendAsyncMultiple_SingleCommand_Assert_CallsSendOnBothEndpointClient()
+        {
+            var signal = new Subject<Unit>();
+
+            var wrongEndpoint = new FakeServiceEndpoint(typeof(TestServiceCommand1));
+            var wrongCommands = wrongEndpoint.Messages.TakeUntil(signal).ToList().ToTask();
+            var correctEndpoint = new FakeServiceEndpoint(typeof(TestServiceCommand1));
+            var correctCommands = correctEndpoint.Messages.TakeUntil(signal).ToList().ToTask();
+
+            var serviceEndpointClients = new[] { wrongEndpoint, correctEndpoint };
+            var serviceEndpoints = Enumerable.Empty<IServiceEndpoint<IMessage, ICommand, IEvent, IRequest, IResponse>>();
+            var sut = new ServiceBusClient<IMessage, ICommand, IEvent, IRequest, IResponse>(serviceEndpointClients, serviceEndpoints, new DefaultRequestCorrelationProvider());
+
+            var cmd = new TestServiceCommand1();
+            var commands = new[] { cmd };
+
+            await sut.SendAsync(commands);
+
+            signal.OnNext(Unit.Default);
+
+            var sentCommands1 = await wrongCommands;
+            Assert.NotEmpty(sentCommands1);
+            Assert.Contains(cmd, sentCommands1);
+            var sendCommands2 = await correctCommands;
+            Assert.NotEmpty(sendCommands2);
+            Assert.Contains(cmd, sendCommands2);
+        }
+    }
+}

--- a/Obvs/IServiceBusClient.cs
+++ b/Obvs/IServiceBusClient.cs
@@ -194,9 +194,14 @@ namespace Obvs
 
         public Task SendAsync(IEnumerable<TCommand> commands)
         {
+            var commandsResovled = commands.ToArray();
+
+            if (commandsResovled.Length == 0)
+                return Task.FromResult(true);
+
             var exceptions = new List<Exception>();
             
-            var tasks = commands.ToArray().Select(command => Catch(() => SendAsync(command), exceptions)).ToArray();
+            var tasks = commandsResovled.Select(command => Catch(() => SendAsync(command), exceptions)).ToArray();
 
             if (exceptions.Any())
             {

--- a/Obvs/IServiceBusClient.cs
+++ b/Obvs/IServiceBusClient.cs
@@ -205,7 +205,7 @@ namespace Obvs
 
             if (exceptions.Any())
             {
-                throw new AggregateException(CommandErrorMessage(), exceptions.Cast<AggregateException>().SelectMany(e => e.InnerExceptions));
+                throw new AggregateException(CommandErrorMessage(), exceptions.SelectMany(_ => _ is AggregateException ? (IList<Exception>)((AggregateException)_).InnerExceptions : new []{_}));
             }
 
             if (tasks.Length == 0)


### PR DESCRIPTION
The recently added check for missing endpoints has resulted in a subtle API change where attempting to send an empty Enumerable will throw. This is a really difficult API change to migrate to due to it being a run-time error and seems unintentional. 

Instead I've changed the API back to allow an empty Enumerable.

Also added some tests for the scenario. This highlighted a bug in the exception handling that I fixed.
