### PR TITLE
Depend on System.Reactive.PlatformServices instead of System.Reactive…

### DIFF
--- a/Obvs/Obvs.csproj
+++ b/Obvs/Obvs.csproj
@@ -14,13 +14,14 @@
   <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard1.6' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
-    <PackageReference Include="System.Reactive" Version="3.1.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.0.3" />
     <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
-    <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
-    <PackageReference Include="System.Reactive" Version="3.1.1" />
+    <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />   
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
+  </ItemGroup>
+  <ItemGroup>    
+    <PackageReference Include="System.Reactive.PlatformServices" Version="3.1.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
… to avoid adding System.Reactive.Windows.Threading when targeting .net Framework 4.5. In particular avoid adding a reference to WindowsBase.