### PR TITLE
Augmented IMessageSource in a backwards compatible manner to support custom concurrency and advanced reactive testing scenarios

### DIFF
--- a/Obvs.Tests/Obvs.Tests.csproj
+++ b/Obvs.Tests/Obvs.Tests.csproj
@@ -5,13 +5,14 @@
     <Copyright>Copyright © Christopher Read 2014</Copyright>
     <Authors />
     <IsPackable>false</IsPackable>
+    <GenerateFullPaths>true</GenerateFullPaths>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FakeItEasy" Version="4.1.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="FakeItEasy" Version="4.9.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Microsoft.Reactive.Testing" Version="3.1.1" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Obvs\Obvs.csproj" />

--- a/Obvs.Tests/TestMergedMessageSource.cs
+++ b/Obvs.Tests/TestMergedMessageSource.cs
@@ -1,79 +1,50 @@
 ﻿using System;
+using System.Reactive.Concurrency;
 using System.Reactive.Linq;
+
 using FakeItEasy;
+
 using Obvs.Types;
+
 using Xunit;
 
-namespace Obvs.Tests
-{
-    public class TestMergedMessageSource
-    {
+namespace Obvs.Tests {
+
+    public class TestMergedMessageSource {
         [Fact]
-        public void ShouldOnlySubscribeToUnderlyingSourcesOnce()
-        {
+        public void ShouldOnlySubscribeToUnderlyingSourcesOnce() {
             IMessageSource<IEvent> source1 = A.Fake<IMessageSource<IEvent>>();
             IMessageSource<IMessage> source2 = A.Fake<IMessageSource<IMessage>>();
             IObservable<IEvent> observable1 = A.Fake<IObservable<IEvent>>();
             IObservable<IMessage> observable2 = A.Fake<IObservable<IMessage>>();
             IObserver<IMessage> observer = A.Fake<IObserver<IMessage>>();
+            var scheduler = A.Fake<IScheduler>();
+            
+            A.CallTo(() => source1.GetMessages(A<IScheduler>._)).Returns(observable1);
+            A.CallTo(() => source2.GetMessages(A<IScheduler>._)).Returns(observable2);
 
-            A.CallTo(() => source1.Messages).Returns(observable1);
-            A.CallTo(() => source2.Messages).Returns(observable2);
+            MergedMessageSource<IMessage> mergedMessageSource = new MergedMessageSource<IMessage>(new [] { source1, source2 });
 
-            MergedMessageSource<IMessage> mergedMessageSource = new MergedMessageSource<IMessage>(new[] { source1, source2 });
+            var mergedMessagesObservable = mergedMessageSource.GetMessages(scheduler);
+            IDisposable sub1 = mergedMessagesObservable.OfType<IEvent>().Subscribe(observer);
+            IDisposable sub2 = mergedMessagesObservable.OfType<IMessage>().Subscribe(observer);
+            
+            A.CallTo(() => source1.GetMessages(A<IScheduler>._))
+                .MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => observable1.Subscribe(A<IObserver<IMessage>>._))
+                .MustHaveHappened(Repeated.Exactly.Once);
 
-            IDisposable sub1 = mergedMessageSource.Messages.OfType<IEvent>().Subscribe(observer);
-            IDisposable sub2 = mergedMessageSource.Messages.OfType<IMessage>().Subscribe(observer);
-
-            A.CallTo(() => source1.Messages).MustHaveHappened(Repeated.Exactly.Once);
-            A.CallTo(() => observable1.Subscribe(A<IObserver<IMessage>>._)).MustHaveHappened(Repeated.Exactly.Once);
-
-            A.CallTo(() => source2.Messages).MustHaveHappened(Repeated.Exactly.Once);
-            A.CallTo(() => observable2.Subscribe(A<IObserver<IMessage>>._)).MustHaveHappened(Repeated.Exactly.Once);
-
+            A.CallTo(() => source2.GetMessages(A<IScheduler>._))
+                .MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => observable2.Subscribe(A<IObserver<IMessage>>._))
+                .MustHaveHappened(Repeated.Exactly.Once);
+            
             sub1.Dispose();
             sub2.Dispose();
         }
 
         [Fact]
-        public void ShouldReturnMessagesFromUnderlyingSources()
-        {
-            IMessageSource<IEvent> source1 = A.Fake<IMessageSource<IEvent>>();
-            IMessageSource<IMessage> source2 = A.Fake<IMessageSource<IMessage>>();
-            IObservable<IEvent> observable1 = A.Fake<IObservable<IEvent>>();
-            IObservable<IMessage> observable2 = A.Fake<IObservable<IMessage>>();
-            IObserver<IMessage> observer = A.Fake<IObserver<IMessage>>();
-            IObserver<IEvent> internalObserver1 = null;
-            IObserver<IMessage> internalObserver2 = null;
-
-            A.CallTo(() => source1.Messages).Returns(observable1);
-            A.CallTo(() => source2.Messages).Returns(observable2);
-            A.CallTo(() => observable1.Subscribe(A<IObserver<IEvent>>._)).Invokes(call => internalObserver1 = call.GetArgument<IObserver<IEvent>>(0));
-            A.CallTo(() => observable2.Subscribe(A<IObserver<IMessage>>._)).Invokes(call => internalObserver2 = call.GetArgument<IObserver<IMessage>>(0));
-
-            MergedMessageSource<IMessage> mergedMessageSource = new MergedMessageSource<IMessage>(new[] { source1, source2 });
-
-            IDisposable sub1 = mergedMessageSource.Messages.OfType<IEvent>().Subscribe(observer);
-            IDisposable sub2 = mergedMessageSource.Messages.OfType<IMessage>().Subscribe(observer);
-
-            Assert.NotNull(internalObserver1);
-            Assert.NotNull(internalObserver2);
-
-            IEvent ev1 = A.Fake<IEvent>();
-            IMessage msg2 = A.Fake<IMessage>();
-            internalObserver1.OnNext(ev1);
-            internalObserver2.OnNext(msg2);
-
-            A.CallTo(() => observer.OnNext(ev1)).MustHaveHappened(Repeated.Exactly.Twice);
-            A.CallTo(() => observer.OnNext(msg2)).MustHaveHappened(Repeated.Exactly.Once);
-
-            sub1.Dispose();
-            sub2.Dispose();
-        }
-
-        [Fact]
-        public void ShouldDisposeUnderlyingSubscriptionOnlyWhenAllSubscriptionsDisposed()
-        {
+        public void ShouldReturnMessagesFromUnderlyingSources() {
             IMessageSource<IEvent> source1 = A.Fake<IMessageSource<IEvent>>();
             IMessageSource<IMessage> source2 = A.Fake<IMessageSource<IMessage>>();
             IObservable<IEvent> observable1 = A.Fake<IObservable<IEvent>>();
@@ -81,40 +52,80 @@ namespace Obvs.Tests
             IObserver<IMessage> observer = A.Fake<IObserver<IMessage>>();
             IObserver<IEvent> internalObserver1 = null;
             IObserver<IMessage> internalObserver2 = null;
+            var scheduler = A.Fake<IScheduler>();
 
-            A.CallTo(() => source1.Messages).Returns(observable1);
-            A.CallTo(() => source2.Messages).Returns(observable2);
-            A.CallTo(() => observable1.Subscribe(A<IObserver<IEvent>>._)).Invokes(call => internalObserver1 = call.GetArgument<IObserver<IEvent>>(0));
-            A.CallTo(() => observable2.Subscribe(A<IObserver<IMessage>>._)).Invokes(call => internalObserver2 = call.GetArgument<IObserver<IMessage>>(0));
+        A.CallTo(() => source1.GetMessages(A<IScheduler>._)).Returns(observable1);
+        A.CallTo(() => source2.GetMessages(A<IScheduler>._)).Returns(observable2);
+        A.CallTo(() => observable1.Subscribe(A<IObserver<IEvent>>._))
+            .Invokes(call => internalObserver1 = call.GetArgument<IObserver<IEvent>>(0));
+        A.CallTo(() => observable2.Subscribe(A<IObserver<IMessage>>._))
+            .Invokes(call => internalObserver2 = call.GetArgument<IObserver<IMessage>>(0));
 
-            MergedMessageSource<IMessage> mergedMessageSource = new MergedMessageSource<IMessage>(new[] { source1, source2 });
+        MergedMessageSource<IMessage> mergedMessageSource = new MergedMessageSource<IMessage>(new [] { source1, source2 });
+        var mergedMessagesObservable = mergedMessageSource.GetMessages(scheduler);
+        var sub1 = mergedMessagesObservable.OfType<IEvent>().Subscribe(observer);
+        var sub2 = mergedMessagesObservable.OfType<IMessage>().Subscribe(observer);
 
-            IDisposable sub1 = mergedMessageSource.Messages.OfType<IEvent>().Subscribe(observer);
-            IDisposable sub2 = mergedMessageSource.Messages.OfType<IMessage>().Subscribe(observer);
+        Assert.NotNull(internalObserver1);
+        Assert.NotNull(internalObserver2);
 
-            Assert.NotNull(internalObserver1);
-            Assert.NotNull(internalObserver2);
+        IEvent ev1 = A.Fake<IEvent>();
+        IMessage msg2 = A.Fake<IMessage>();
+        internalObserver1.OnNext(ev1);
+        internalObserver2.OnNext(msg2);
 
-            IEvent ev1 = A.Fake<IEvent>();
-            IMessage msg1 = A.Fake<IMessage>();
-            IMessage msg2 = A.Fake<IMessage>();
+        A.CallTo(() => observer.OnNext(ev1)).MustHaveHappened(Repeated.Exactly.Twice);
+        A.CallTo(() => observer.OnNext(msg2)).MustHaveHappened(Repeated.Exactly.Once);
 
-            internalObserver1.OnNext(ev1);
-            A.CallTo(() => observer.OnNext(ev1)).MustHaveHappened(Repeated.Exactly.Twice);
-
-            // dispose of first subscription
-            sub1.Dispose();
-
-            // second subscription should still be active
-            internalObserver2.OnNext(msg1);
-            A.CallTo(() => observer.OnNext(msg1)).MustHaveHappened(Repeated.Exactly.Once);
-
-            // dispose of second subscription
-            sub2.Dispose();
-
-            // no subscriptions should be active
-            internalObserver2.OnNext(msg2);
-            A.CallTo(() => observer.OnNext(msg2)).MustNotHaveHappened();
-        }
+        sub1.Dispose();
+        sub2.Dispose();
     }
+
+    [Fact]
+    public void ShouldDisposeUnderlyingSubscriptionOnlyWhenAllSubscriptionsDisposed() {
+        IMessageSource<IEvent> source1 = A.Fake<IMessageSource<IEvent>>();
+        IMessageSource<IMessage> source2 = A.Fake<IMessageSource<IMessage>>();
+        IObservable<IEvent> observable1 = A.Fake<IObservable<IEvent>>();
+        IObservable<IMessage> observable2 = A.Fake<IObservable<IMessage>>();
+        IObserver<IMessage> observer = A.Fake<IObserver<IMessage>>();
+        IObserver<IEvent> internalObserver1 = null;
+        IObserver<IMessage> internalObserver2 = null;
+        var scheduler = A.Fake<IScheduler>();
+
+        A.CallTo(() => source1.GetMessages(A<IScheduler>._)).Returns(observable1);
+        A.CallTo(() => source2.GetMessages(A<IScheduler>._)).Returns(observable2);
+        A.CallTo(() => observable1.Subscribe(A<IObserver<IEvent>>._)).Invokes(call => internalObserver1 = call.GetArgument<IObserver<IEvent>>(0));
+        A.CallTo(() => observable2.Subscribe(A<IObserver<IMessage>>._)).Invokes(call => internalObserver2 = call.GetArgument<IObserver<IMessage>>(0));
+
+        MergedMessageSource<IMessage> mergedMessageSource = new MergedMessageSource<IMessage>(new [] { source1, source2 });
+
+        var mergedMessagesObservable = mergedMessageSource.GetMessages(scheduler);
+        IDisposable sub1 = mergedMessagesObservable.OfType<IEvent>().Subscribe(observer);
+        IDisposable sub2 = mergedMessagesObservable.OfType<IMessage>().Subscribe(observer);
+
+        Assert.NotNull(internalObserver1);
+        Assert.NotNull(internalObserver2);
+
+        IEvent ev1 = A.Fake<IEvent>();
+        IMessage msg1 = A.Fake<IMessage>();
+        IMessage msg2 = A.Fake<IMessage>();
+
+        internalObserver1.OnNext(ev1);
+        A.CallTo(() => observer.OnNext(ev1)).MustHaveHappened(Repeated.Exactly.Twice);
+
+        // dispose of first subscription
+        sub1.Dispose();
+
+        // second subscription should still be active
+        internalObserver2.OnNext(msg1);
+        A.CallTo(() => observer.OnNext(msg1)).MustHaveHappened(Repeated.Exactly.Once);
+
+        // dispose of second subscription
+        sub2.Dispose();
+
+        // no subscriptions should be active
+        internalObserver2.OnNext(msg2);
+        A.CallTo(() => observer.OnNext(msg2)).MustNotHaveHappened();
+    }
+}
 }

--- a/Obvs.Tests/TestMessageSourceConverter.cs
+++ b/Obvs.Tests/TestMessageSourceConverter.cs
@@ -1,39 +1,47 @@
 using System;
+using System.Reactive.Concurrency;
+
 using FakeItEasy;
+
 using Obvs.Types;
+
 using Xunit;
 
-namespace Obvs.Tests
-{
-    
-    public class TestMessageSourceConverter
-    {
+namespace Obvs.Tests {
+
+    public class TestMessageSourceConverter {
         public class TestMessage : IMessage { }
 
         [Fact]
-        public void ShouldSubscribeToUnderlyingSourceOnSubscribe()
-        {
+        public void ShouldSubscribeToUnderlyingSourceOnSubscribe() {
             IMessageSource<TestMessage> source = A.Fake<IMessageSource<TestMessage>>();
+            IObservable<TestMessage> sourceMessagesObservable = A.Fake<IObservable<TestMessage>>();
             IMessageSource<TestMessage> sourceConverter = new MessageSourceConverter<TestMessage, TestMessage>(source, A.Fake<IMessageConverter<TestMessage, TestMessage>>());
+            IScheduler scheduler = A.Fake<IScheduler>();
             IObserver<TestMessage> consumer = A.Fake<IObserver<TestMessage>>();
 
-            sourceConverter.Messages.Subscribe(consumer);
+            A.CallTo(() => source.GetMessages(A<IScheduler>._)).Returns(sourceMessagesObservable);
+            sourceConverter.GetMessages(scheduler).Subscribe(consumer);
 
-            A.CallTo(() => source.Messages.Subscribe(A<IObserver<TestMessage>>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => source.GetMessages(scheduler).Subscribe(A<IObserver<TestMessage>>.Ignored))
+                .MustHaveHappened(Repeated.Exactly.Once);
         }
 
         [Fact]
-        public void ShouldConvertAndPublishMessages()
-        {
-            IMessageSource<TestMessage> source = A.Fake<IMessageSource<TestMessage>>();
-            IMessageConverter<TestMessage, TestMessage> converter = A.Fake<IMessageConverter<TestMessage, TestMessage>>();
-            IMessageSource<TestMessage> sourceConverter = new MessageSourceConverter<TestMessage, TestMessage>(source, converter);
+        public void ShouldConvertAndPublishMessages() {
+            var source = A.Fake<IMessageSource<TestMessage>>();
+            var sourceMessagesObservable = A.Fake<IObservable<TestMessage>>();
+            var converter = A.Fake<IMessageConverter<TestMessage, TestMessage>>();
+            var sourceConverter = new MessageSourceConverter<TestMessage, TestMessage>(source, converter);
             IObserver<TestMessage> internalObserver = null;
-            IObserver<TestMessage> consumer = A.Fake<IObserver<TestMessage>>();
-            TestMessage message = new TestMessage();
-            TestMessage convertedMessage = new TestMessage();
+            var consumer = A.Fake<IObserver<TestMessage>>();
+            var scheduler = A.Fake<IScheduler>();
+            var message = new TestMessage();
+            var convertedMessage = new TestMessage();
 
-            A.CallTo(() => source.Messages.Subscribe(A<IObserver<TestMessage>>.Ignored)).Invokes(call => internalObserver = call.GetArgument<IObserver<TestMessage>>(0));
+            A.CallTo(() => source.GetMessages(A<IScheduler>._)).Returns(sourceMessagesObservable);
+            A.CallTo(() => source.GetMessages(scheduler).Subscribe(A<IObserver<TestMessage>>.Ignored))
+                .Invokes(call => internalObserver = call.GetArgument<IObserver<TestMessage>>(0));
             A.CallTo(() => converter.Convert(message)).Returns(convertedMessage);
 
             sourceConverter.Messages.Subscribe(consumer);
@@ -45,16 +53,19 @@ namespace Obvs.Tests
         }
 
         [Fact]
-        public void ShouldNotPublishInvalidMessages()
-        {
+        public void ShouldNotPublishInvalidMessages() {
             IMessageSource<TestMessage> source = A.Fake<IMessageSource<TestMessage>>();
+            IObservable<TestMessage> sourceMessagesObservable = A.Fake<IObservable<TestMessage>>();
             IMessageConverter<TestMessage, TestMessage> converter = A.Fake<IMessageConverter<TestMessage, TestMessage>>();
             IMessageSource<TestMessage> sourceConverter = new MessageSourceConverter<TestMessage, TestMessage>(source, converter);
             IObserver<TestMessage> internalObserver = null;
             IObserver<TestMessage> consumer = A.Fake<IObserver<TestMessage>>();
+            IScheduler scheduler = A.Fake<IScheduler>();
             TestMessage message = new TestMessage();
-
-            A.CallTo(() => source.Messages.Subscribe(A<IObserver<TestMessage>>.Ignored)).Invokes(call => internalObserver = call.GetArgument<IObserver<TestMessage>>(0));
+            
+            A.CallTo(() => source.GetMessages(A<IScheduler>._)).Returns(sourceMessagesObservable);
+            A.CallTo(() => source.GetMessages(scheduler).Subscribe(A<IObserver<TestMessage>>.Ignored))
+                .Invokes(call => internalObserver = call.GetArgument<IObserver<TestMessage>>(0));
             A.CallTo(() => converter.Convert(message)).Returns(null);
 
             sourceConverter.Messages.Subscribe(consumer);

--- a/Obvs/IMessageSource.cs
+++ b/Obvs/IMessageSource.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 
 namespace Obvs
@@ -7,18 +8,36 @@ namespace Obvs
         where TMessage : class
     {
         IObservable<TMessage> Messages { get; }
+
+        /// <summary>
+        /// Observe messages from source with a specific scheduler
+        /// </summary>
+        /// <param name="scheduler">The scheduler implementation to use</param>
+        /// <returns>Observable of messages in the source</returns>
+        IObservable<TMessage> GetMessages(IScheduler scheduler);
     }
 
-    public class DefaultMessageSource<TMessage> : IMessageSource<TMessage>
-        where TMessage : class
+    public abstract class BaseMessageSource<TMessage> : IMessageSource<TMessage> where TMessage: class
     {
-        public void Dispose()
-        {
+        public virtual IObservable<TMessage> Messages {
+            get => GetMessages(DefaultScheduler.Instance);
         }
 
-        public IObservable<TMessage> Messages
+        public virtual void Dispose() {}
+
+        public abstract IObservable<TMessage> GetMessages(IScheduler scheduler);
+    }
+
+
+
+    public class DefaultMessageSource<TMessage> : BaseMessageSource<TMessage>
+        where TMessage : class
+    {
+
+        /// <inheritdoc />
+        public override IObservable<TMessage> GetMessages(IScheduler scheduler)
         {
-            get { return Observable.Empty<TMessage>(); }
+            return Observable.Empty<TMessage>(scheduler);
         }
     }  
 }

--- a/Obvs/MessageSourceConverter.cs
+++ b/Obvs/MessageSourceConverter.cs
@@ -1,9 +1,10 @@
 using System;
+using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 
 namespace Obvs
 {
-    public class MessageSourceConverter<TFrom, TTo> : IMessageSource<TTo>
+    public class MessageSourceConverter<TFrom, TTo> : BaseMessageSource<TTo>
         where TTo : class
         where TFrom : class
     {
@@ -16,14 +17,12 @@ namespace Obvs
             _converter = converter;
         }
 
-        public IObservable<TTo> Messages
-        {
-            get
-            {
-                return _source.Messages
-                              .Select(ConvertedMessage)
-                              .Where(MessageIsValid);
-            }
+
+        /// <inheritdoc />
+        public override IObservable<TTo> GetMessages(IScheduler scheduler) {
+            return _source.GetMessages(scheduler)
+                            .Select(ConvertedMessage)
+                            .Where(MessageIsValid);
         }
 
         private static bool MessageIsValid(TTo msg)
@@ -36,7 +35,7 @@ namespace Obvs
             return _converter.Convert(obj);
         }
 
-        public void Dispose()
+        public override void Dispose()
         {
             _source.Dispose();
             _converter.Dispose();

--- a/Obvs/Obvs.csproj
+++ b/Obvs/Obvs.csproj
@@ -9,14 +9,16 @@
     <PackageProjectUrl>http://christopherread.github.io/Obvs</PackageProjectUrl>
     <PackageTags>obvs messaging microservice bus messagebus rx reactive servicebus</PackageTags>
     <PackageReleaseNotes>New csproj format</PackageReleaseNotes>
+    <GenerateFullPaths>true</GenerateFullPaths>
     <Description>An observable microservice bus .NET library, based on Reactive Extensions. Search 'Obvs' for other transport, serialization, and logging extensions.</Description>
   </PropertyGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' != 'net45' ">
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.0.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
     <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />   
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />


### PR DESCRIPTION
Augmented IMessageSource in a backward compatible manner to support the specification of an external IScheduler to tweak concurrent execution and enable richer testing using TestScheduler.

Upgraded all possible package dependencies without breaking support for currently targetted frameworks.
Revised test definitions to accommodate the change in IMessageSource.