### PR TITLE
Use a full IServiceBus for local bus and remove the Subscribe() functionality from the IServiceBus interface

### DIFF
--- a/Obvs.Tests/TestSubjectServiceBus.cs
+++ b/Obvs.Tests/TestSubjectServiceBus.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using Obvs.Types;
+using Xunit;
+
+namespace Obvs.Tests
+{
+    
+    public class TestSubjectServiceBus
+    {
+        private readonly SubjectServiceBus _testObj;
+
+        public TestSubjectServiceBus()
+        {
+            _testObj = new SubjectServiceBus(new DefaultRequestCorrelationProvider());
+        }
+
+        [Fact]
+        public void PublishBlocksUntilMessageHasBeenConsumed()
+        {
+            var subscriberThreadId = -1;
+            _testObj.Events.Subscribe(_ => subscriberThreadId = Thread.CurrentThread.ManagedThreadId);
+
+            var threadId = Thread.CurrentThread.ManagedThreadId;
+
+            var task = _testObj.PublishAsync(new TestServiceEvent1());
+
+            Assert.NotEqual(-1, subscriberThreadId);
+            Assert.Equal(threadId, subscriberThreadId);
+
+            task.Wait();
+        }
+
+        [Fact]
+        public void SendBlocksUntilMessageHasBeenConsumed()
+        {
+            var subscriberThreadId = -1;
+            _testObj.Commands.Subscribe(_ => subscriberThreadId = Thread.CurrentThread.ManagedThreadId);
+
+            var threadId = Thread.CurrentThread.ManagedThreadId;
+
+            var task = _testObj.SendAsync(new TestServiceCommand1());
+
+            Assert.NotEqual(-1, subscriberThreadId);
+            Assert.Equal(threadId, subscriberThreadId);
+
+            task.Wait();
+        }
+
+        [Fact]
+        public void GetResponsesReturnsResponseFromReply()
+        {
+            var requests = new List<IRequest>();
+            var responses = new List<IResponse>();
+
+            var sub1 = _testObj.Requests
+                .Subscribe(req =>
+                {
+                    requests.Add(req);
+                    _testObj.ReplyAsync(req, new TestServiceResponse1());
+                });
+
+            var sub2 = _testObj.GetResponses(new TestServiceRequest1())
+                .Subscribe(res => responses.Add(res));
+
+            Assert.NotEmpty(requests);
+            Assert.IsType<TestServiceRequest1>(requests[0]);
+
+            Assert.NotEmpty(responses);
+            Assert.IsType<TestServiceResponse1>(responses[0]);
+
+            sub1.Dispose();
+            sub2.Dispose();
+        }
+
+
+        [Fact]
+        public void PublishReturnsWithNoObservers()
+        {
+            Assert.True(_testObj.PublishAsync(new TestServiceEvent1()).Wait(1));
+        }
+
+        [Fact]
+        public void SendReturnsWithNoObservers()
+        {
+            Assert.True(_testObj.SendAsync(new TestServiceCommand1()).Wait(1));
+        }
+    }
+}

--- a/Obvs.sln.DotSettings
+++ b/Obvs.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Obvs/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/Obvs/Configuration/ICanAddEndpointOrLoggingOrCreate.cs
+++ b/Obvs/Configuration/ICanAddEndpointOrLoggingOrCreate.cs
@@ -147,7 +147,7 @@ namespace Obvs.Configuration
         /// </summary>
         /// <param name="localBus">Optionally allows your own local bus instance to be used</param>
         /// <returns></returns>
-        ICanSpecifyLocalBusOptions<TMessage, TCommand, TEvent, TRequest, TResponse> PublishLocally(IMessageBus<TMessage> localBus = null);
+        ICanSpecifyLocalBusOptions<TMessage, TCommand, TEvent, TRequest, TResponse> PublishLocally(IServiceBus<TMessage, TCommand, TEvent, TRequest, TResponse> localBus = null);
     }
 
     public interface ICanSpecifyLocalBusOptions<TMessage, TCommand, TEvent, TRequest, TResponse>

--- a/Obvs/Configuration/ICanAddEndpointOrLoggingOrCreate.cs
+++ b/Obvs/Configuration/ICanAddEndpointOrLoggingOrCreate.cs
@@ -158,14 +158,20 @@ namespace Obvs.Configuration
         where TResponse : class, TMessage
     {
         /// <summary>
-        /// Configures message types for which this process is configured as a server to also be sent and received by local subscribers
+        /// Configures only messages for which this bus is configured as a server to also be received by local subscribers.
         /// </summary>
         ICanSpecifyLoggingOrMonitoringOrCreate<TMessage, TCommand, TEvent, TRequest, TResponse> AnyMessagesWithNoEndpointClients();
 
         /// <summary>
-        /// Configures message types which have no endpoints configured to be sent and received by local subscribers
+        /// Configures only messages for which this bus has no endpoints to be received by local subscribers.
         /// </summary>
         ICanSpecifyLoggingOrMonitoringOrCreate<TMessage, TCommand, TEvent, TRequest, TResponse> OnlyMessagesWithNoEndpoints();
+
+        /// <summary>
+        /// Configures all messages to be received by local subscribers. Warning: external transport must be configured
+        /// independently to filter out local messages, otherwise this setting may result in duplicate messages being received.
+        /// </summary>
+        ICanSpecifyLoggingOrMonitoringOrCreate<TMessage, TCommand, TEvent, TRequest, TResponse> AllMessages();
     }
 
     public interface ICanSpecifyMonitoring<TMessage, TCommand, TEvent, TRequest, TResponse> 

--- a/Obvs/Configuration/ServiceBusFluentCreator.cs
+++ b/Obvs/Configuration/ServiceBusFluentCreator.cs
@@ -152,6 +152,12 @@ namespace Obvs.Configuration
             return this;
         }
 
+        public ICanSpecifyLoggingOrMonitoringOrCreate<TMessage, TCommand, TEvent, TRequest, TResponse> AllMessages()
+        {
+            _localBusOption = LocalBusOptions.AllMessages;
+            return this;
+        }
+
         public ICanSpecifyLoggingOrCreate<TMessage, TCommand, TEvent, TRequest, TResponse> UsingMonitor(IMonitorFactory<TMessage> monitorFactory)
         {
             _monitorFactory = monitorFactory;
@@ -168,6 +174,7 @@ namespace Obvs.Configuration
     public enum LocalBusOptions
     {
         MessagesWithNoEndpointClients = 0,
-        MessagesWithNoEndpoints = 1
+        MessagesWithNoEndpoints = 1,
+        AllMessages = 3
     }
 }

--- a/Obvs/Configuration/ServiceBusFluentCreator.cs
+++ b/Obvs/Configuration/ServiceBusFluentCreator.cs
@@ -7,7 +7,10 @@ using Obvs.Monitoring;
 
 namespace Obvs.Configuration
 {
-    public class ServiceBusFluentCreator<TMessage, TCommand, TEvent, TRequest, TResponse> : ICanAddEndpointOrLoggingOrCorrelationOrCreate<TMessage, TCommand, TEvent, TRequest, TResponse>, ICanSpecifyLocalBusOptions<TMessage, TCommand, TEvent, TRequest, TResponse> where TMessage : class
+    public class ServiceBusFluentCreator<TMessage, TCommand, TEvent, TRequest, TResponse> : 
+        ICanAddEndpointOrLoggingOrCorrelationOrCreate<TMessage, TCommand, TEvent, TRequest, TResponse>, 
+        ICanSpecifyLocalBusOptions<TMessage, TCommand, TEvent, TRequest, TResponse> 
+        where TMessage : class
         where TCommand : class, TMessage
         where TEvent : class, TMessage
         where TRequest : class, TMessage
@@ -20,7 +23,8 @@ namespace Obvs.Configuration
         private IRequestCorrelationProvider<TRequest, TResponse> _requestCorrelationProvider;
         private Func<Type, LogLevel> _logLevelSend;
         private Func<Type, LogLevel> _logLevelReceive;
-        private IMessageBus<TMessage> _localBus;
+        private IServiceBus<TMessage, TCommand, TEvent, TRequest, TResponse> _localBus;
+        private bool _useLocalBus = false;
         private LocalBusOptions _localBusOption = LocalBusOptions.MessagesWithNoEndpointClients;
         private IMonitorFactory<TMessage> _monitorFactory;
 
@@ -54,12 +58,20 @@ namespace Obvs.Configuration
 
         public IServiceBus<TMessage, TCommand, TEvent, TRequest, TResponse> CreateServiceBus()
         {
-            return new ServiceBus<TMessage, TCommand, TEvent, TRequest, TResponse>(GetEndpointClients(), GetEndpoints(), _requestCorrelationProvider, _localBus, _localBusOption);
+            return new ServiceBus<TMessage, TCommand, TEvent, TRequest, TResponse>(
+                GetEndpointClients(), 
+                GetEndpoints(), 
+                _requestCorrelationProvider, 
+                _useLocalBus ? (_localBus ?? new SubjectServiceBus<TMessage, TCommand, TEvent, TRequest, TResponse>(_requestCorrelationProvider)) : null, 
+                _localBusOption);
         }
 
         public IServiceBusClient<TMessage, TCommand, TEvent, TRequest, TResponse> CreateServiceBusClient()
         {
-            return new ServiceBusClient<TMessage, TCommand, TEvent, TRequest, TResponse>(GetEndpointClients(), GetEndpoints(), _requestCorrelationProvider);
+            return new ServiceBusClient<TMessage, TCommand, TEvent, TRequest, TResponse>(
+                GetEndpointClients(), 
+                GetEndpoints(), 
+                _requestCorrelationProvider);
         }
 
         public ICanAddEndpointOrLoggingOrCorrelationOrCreate<TMessage, TCommand, TEvent, TRequest, TResponse> WithEndpoint(IServiceEndpointClient<TMessage, TCommand, TEvent, TRequest, TResponse> endpointClient)
@@ -97,7 +109,7 @@ namespace Obvs.Configuration
         {
             if (requestCorrelationProvider == null)
             {
-                throw new ArgumentNullException("requestCorrelationProvider");
+                throw new ArgumentNullException(nameof(requestCorrelationProvider));
             }
             
             _requestCorrelationProvider = requestCorrelationProvider;
@@ -134,9 +146,10 @@ namespace Obvs.Configuration
             return endpointsWithMonitoring;
         }
 
-        ICanSpecifyLocalBusOptions<TMessage, TCommand, TEvent, TRequest, TResponse> ICanSpecifyLocalBus<TMessage, TCommand, TEvent, TRequest, TResponse>.PublishLocally(IMessageBus<TMessage> localBus)
+        ICanSpecifyLocalBusOptions<TMessage, TCommand, TEvent, TRequest, TResponse> ICanSpecifyLocalBus<TMessage, TCommand, TEvent, TRequest, TResponse>.PublishLocally(IServiceBus<TMessage, TCommand, TEvent, TRequest, TResponse> localBus)
         {
-            _localBus = localBus ?? new SubjectMessageBus<TMessage>(); // use default implementation if not supplied
+            _localBus = localBus;
+            _useLocalBus = true;
             return this;
         }
 

--- a/Obvs/IRequestCorrelationProvider.cs
+++ b/Obvs/IRequestCorrelationProvider.cs
@@ -17,7 +17,7 @@ namespace Obvs
         bool AreCorrelated(TRequest request, TResponse response);
     }
 
-    public class DefaultRequestCorrelationProvider : IRequestCorrelationProvider<IRequest, IResponse>
+    public class DefaultRequestCorrelationProvider : IRequestCorrelationProvider
     {
         public void SetRequestCorrelationIds(IRequest request)
         {

--- a/Obvs/IServiceBusClient.cs
+++ b/Obvs/IServiceBusClient.cs
@@ -1,11 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reactive.Concurrency;
-using System.Reactive.Disposables;
 using System.Reactive.Linq;
-using System.Reflection;
-using System.Reflection.Emit;
 using System.Threading.Tasks;
 using Obvs.Configuration;
 using Obvs.Extensions;
@@ -34,8 +30,6 @@ namespace Obvs
         IObservable<T> GetResponse<T>(TRequest request) where T : TResponse;
 
         IObservable<Exception> Exceptions { get; }
-
-        IDisposable Subscribe(object subscriber, IScheduler scheduler = null);
     }
 
     public class ServiceBusClient : IServiceBusClient, IDisposable
@@ -76,11 +70,6 @@ namespace Obvs
 
         public IObservable<Exception> Exceptions => _serviceBusClient.Exceptions;
 
-        public IDisposable Subscribe(object subscriber, IScheduler scheduler = null)
-        {
-            return _serviceBusClient.Subscribe(subscriber, scheduler);
-        }
-
         public void Dispose()
         {
             ((IDisposable)_serviceBusClient).Dispose();
@@ -96,9 +85,7 @@ namespace Obvs
     {
         protected readonly IEnumerable<IServiceEndpoint<TMessage, TCommand, TEvent, TRequest, TResponse>> Endpoints;
         private readonly IEnumerable<IServiceEndpointClient<TMessage, TCommand, TEvent, TRequest, TResponse>> _endpointClients;
-        private readonly IObservable<TEvent> _events;
         private readonly IRequestCorrelationProvider<TRequest, TResponse> _requestCorrelationProvider;
-        private readonly List<KeyValuePair<object, IObservable<TMessage>>> _subscribers;
         private readonly IServiceBus<TMessage, TCommand, TEvent, TRequest, TResponse> _localBus;
         private readonly LocalBusOptions _localBusOption;
 
@@ -114,17 +101,16 @@ namespace Obvs
 
             _endpointClients = endpointClients.ToArray();
 
-            _events = _endpointClients
+            Events = _endpointClients
                 .Select(endpointClient => endpointClient.EventsWithErrorHandling(_exceptions))
                 .Merge()
                 .Merge(GetLocalEvents())
                 .PublishRefCountRetriable();
 
             _requestCorrelationProvider = requestCorrelationProvider;
-            _subscribers = new List<KeyValuePair<object, IObservable<TMessage>>>();
         }
 
-        public IObservable<TEvent> Events => _events;
+        public IObservable<TEvent> Events { get; }
 
         public Task SendAsync(TCommand command)
         {
@@ -149,7 +135,7 @@ namespace Obvs
             return Task.WhenAll(tasks);
         }
 
-        protected IObservable<TEvent> GetLocalEvents()
+        private IObservable<TEvent> GetLocalEvents()
         {
             return _localBus == null ? Observable.Empty<TEvent>() : _localBus.Events;
         }
@@ -171,7 +157,7 @@ namespace Obvs
                 : Enumerable.Empty<Task>();
         }
 
-        protected IEnumerable<Task> SendLocal(TCommand command, List<Exception> exceptions)
+        private IEnumerable<Task> SendLocal(TCommand command, List<Exception> exceptions)
         {
             return ShouldPublishLocally(command) 
                 ? new[] { Catch(() => _localBus.SendAsync(command), exceptions) } 
@@ -226,7 +212,12 @@ namespace Obvs
 
             if (exceptions.Any())
             {
-                throw new AggregateException(CommandErrorMessage(), exceptions.SelectMany(_ => _ is AggregateException ? (IList<Exception>)((AggregateException)_).InnerExceptions : new []{_}));
+                Exception[] GetInnerExceptions(Exception e) =>
+                    e is AggregateException aggregateException
+                        ? aggregateException.InnerExceptions.ToArray()
+                        : new[] {e};
+
+                throw new AggregateException(CommandErrorMessage(), exceptions.SelectMany(GetInnerExceptions));
             }
 
             if (tasks.Length == 0)
@@ -269,150 +260,6 @@ namespace Obvs
         public IObservable<T> GetResponse<T>(TRequest request) where T : TResponse
         {
             return GetResponses(request).OfType<T>().Take(1);
-        }
-
-        public virtual IDisposable Subscribe(object subscriber, IScheduler scheduler = null)
-        {
-            return Subscribe(subscriber, Events, scheduler);
-        }
-
-        protected IDisposable Subscribe(object subscriber, IObservable<TMessage> messages, IScheduler scheduler = null, IObservable<TRequest> requests = null, Action<TRequest, TResponse> onReply = null)
-        {
-            if (subscriber == null)
-            {
-                throw new ArgumentNullException("subscriber");
-            }
-
-            IObservable<TMessage> observable;
-            scheduler = scheduler ?? Scheduler.Default;
-
-            lock (_subscribers)
-            {
-                if (_subscribers.Any(sub => sub.Key == subscriber))
-                {
-                    throw new ArgumentException("Already subscribed", "subscriber");
-                }
-                observable = messages;
-                if (requests != null)
-                {
-                    observable = observable.Merge(requests);
-                }
-                observable = observable.ObserveOn(scheduler);
-                _subscribers.Add(new KeyValuePair<object, IObservable<TMessage>>(subscriber, observable));
-            }
-
-            var subscriberType = subscriber.GetType();
-            var methodHandlers = subscriberType.GetSubscriberMethods<TCommand, TEvent, TRequest, TResponse>();
-            
-            var voidTypeInfo = typeof(void).GetTypeInfo();
-
-            var subscription = new CompositeDisposable();
-            foreach (var methodHandler in methodHandlers)
-            {
-                var methodInfo = methodHandler.Item1;
-                var paramType = methodHandler.Item2;
-                var returnType = methodHandler.Item3;
-
-                Action<object, TMessage> onMessage = null;
-                Func<object, TRequest, IObservable<TResponse>> onRequest = null;
-
-                if (Equals(returnType, voidTypeInfo))
-                {
-                    onMessage = CreateSubscriberAction<TMessage>(subscriberType, methodInfo);
-                }
-                else if (onReply != null)
-                {
-                    onRequest = CreateSubscriberFunc<TRequest, IObservable<TResponse>>(subscriberType, methodInfo);
-                }
-
-                subscription.Add(observable
-                    .Where(message => paramType.IsInstanceOfType(message))
-                    .Subscribe(message =>
-                    {
-                        try
-                        {
-                            if (onMessage != null)
-                            {
-                                onMessage(subscriber, message);
-                            }
-                            else if (onRequest != null && onReply != null)
-                            {
-                                var request = message as TRequest;
-                                onRequest(subscriber, request).Subscribe(response => onReply(request, response));
-                            }
-                        }
-                        catch (Exception exception)
-                        {
-                            _exceptions.OnNext(exception);
-                        }
-                    }));
-            }
-
-            if (!subscription.Any())
-            {
-                throw new ArgumentException("Subscriber needs at least one public method of format 'void OnMessage(TMessage msg)' or 'IObservable<TResponse> OnRequest(TRequest req)'", "subscriber");
-            }
-
-            subscription.Add(Disposable.Create(() =>
-            {
-                lock (_subscribers)
-                {
-                    _subscribers.RemoveAll(sub => sub.Key == subscriber);
-                }
-            }));
-
-            return subscription;
-        }
-
-//        
-//        private static Action<object, TParamType> CreateSubscriberAction<TParamType>(Type subscriberType, MethodInfo methodInfo)
-//        {
-//            var targetObj = Expression.Parameter(typeof(object));
-//            var parameter = Expression.Parameter(typeof(TParamType));
-//            
-//            var castTarget = Expression.Convert(targetObj, subscriberType);
-//            var call = Expression.Call(castTarget, methodInfo, parameter);
-//
-//            return Expression.Lambda<Action<object, TParamType>>(call, targetObj, parameter).Compile();
-//        }
-//
-//        private static Func<object, TParamType, TReturnType> CreateSubscriberFunc<TParamType, TReturnType>(Type subscriberType, MethodInfo methodInfo)
-//        {
-//            var targetObj = Expression.Parameter(typeof(object));
-//            var parameter = Expression.Parameter(typeof(TParamType));
-//            
-//            var castTarget = Expression.Convert(targetObj, subscriberType);
-//            var call = Expression.Call(castTarget, methodInfo, parameter);
-//
-//            return Expression.Lambda<Func<object, TParamType, TReturnType>>(call, targetObj, parameter).Compile();
-//        }
-
-        private static Action<object, TParamType> CreateSubscriberAction<TParamType>(Type subscriberType, MethodInfo methodInfo)
-        {
-            var name = subscriberType.Name + methodInfo.Name + "DynamicMethod";
-            var shim = new DynamicMethod(name, typeof(void), new[] { typeof(object), typeof(TParamType) }, subscriberType);
-            var il = shim.GetILGenerator();
-
-            il.Emit(OpCodes.Ldarg_0); // Load subscriber
-            il.Emit(OpCodes.Ldarg_1); // Load parameter
-            il.Emit(OpCodes.Call, methodInfo); // Invoke method
-            il.Emit(OpCodes.Ret); // void return
-
-            return (Action<object, TParamType>)shim.CreateDelegate(typeof(Action<object, TParamType>));
-        }
-
-        private static Func<object, TParamType, TReturnType> CreateSubscriberFunc<TParamType, TReturnType>(Type subscriberType, MethodInfo methodInfo)
-        {
-            var name = subscriberType.Name + methodInfo.Name + "DynamicMethod";
-            var shim = new DynamicMethod(name, typeof(TReturnType), new[] { typeof(object), typeof(TParamType) }, subscriberType);
-            var il = shim.GetILGenerator();
-
-            il.Emit(OpCodes.Ldarg_0); // Load subscriber
-            il.Emit(OpCodes.Ldarg_1); // Load parameter
-            il.Emit(OpCodes.Call, methodInfo); // Invoke method
-            il.Emit(OpCodes.Ret); // return
-
-            return (Func<object, TParamType, TReturnType>)shim.CreateDelegate(typeof(Func<object, TParamType, TReturnType>));
         }
 
         private IEnumerable<IServiceEndpointClient<TMessage, TCommand, TEvent, TRequest, TResponse>> EndpointClientsThatCanHandle(TMessage message)

--- a/Obvs/SubjectServiceBus.cs
+++ b/Obvs/SubjectServiceBus.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Concurrency;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Threading.Tasks;
+using Obvs.Extensions;
+using Obvs.Types;
+
+namespace Obvs
+{
+    public class SubjectServiceBus : SubjectServiceBus<IMessage, ICommand, IEvent, IRequest, IResponse>, IServiceBus
+    {
+        public SubjectServiceBus(IRequestCorrelationProvider requestCorrelationProvider) 
+            : base(requestCorrelationProvider)
+        {
+        }
+
+        public SubjectServiceBus(IScheduler scheduler, IRequestCorrelationProvider requestCorrelationProvider) 
+            : base(scheduler, requestCorrelationProvider)
+        {
+        }
+    }
+
+    public class SubjectServiceBus<TMessage, TCommand, TEvent, TRequest, TResponse> : IServiceBus<TMessage, TCommand, TEvent, TRequest, TResponse>
+       where TMessage : class
+        where TCommand : class, TMessage
+        where TEvent : class, TMessage
+        where TRequest : class, TMessage
+        where TResponse : class, TMessage
+    {
+        private readonly ISubject<TCommand, TCommand> _commands;
+        private readonly ISubject<TEvent, TEvent> _events;
+        private readonly ISubject<TRequest, TRequest> _requests;
+        private readonly ISubject<TResponse, TResponse> _responses;
+        private readonly IRequestCorrelationProvider<TRequest, TResponse> _requestCorrelationProvider;
+
+        public SubjectServiceBus(IRequestCorrelationProvider<TRequest, TResponse> requestCorrelationProvider)
+            : this(null, requestCorrelationProvider)
+        {
+        }
+
+        public SubjectServiceBus(IScheduler scheduler, IRequestCorrelationProvider<TRequest, TResponse> requestCorrelationProvider)
+        {
+            _requestCorrelationProvider = requestCorrelationProvider;
+            _commands = Subject.Synchronize(new Subject<TCommand>());
+            _events = Subject.Synchronize(new Subject<TEvent>());
+            _requests = Subject.Synchronize(new Subject<TRequest>());
+            _responses = Subject.Synchronize(new Subject<TResponse>());
+
+            Events = scheduler == null
+                ? _events.AsObservable()
+                : _events.ObserveOn(scheduler)
+                    .PublishRefCountRetriable()
+                    .AsObservable();
+
+            Commands = scheduler == null
+                ? _commands.AsObservable()
+                : _commands.ObserveOn(scheduler)
+                    .PublishRefCountRetriable()
+                    .AsObservable();
+
+            Requests = scheduler == null
+                ? _requests.AsObservable()
+                : _requests.ObserveOn(scheduler)
+                    .PublishRefCountRetriable()
+                    .AsObservable();
+        }
+
+        public void Dispose()
+        {
+            // synchronized subjects are anonymous subject underneath,
+            // which don't implement IDisposable
+        }
+
+        public IObservable<TEvent> Events { get; }
+        public IObservable<TRequest> Requests { get; }
+        public IObservable<TCommand> Commands { get; }
+        public IObservable<Exception> Exceptions => Observable.Empty<Exception>();
+
+        public Task SendAsync(TCommand command)
+        {
+            _commands.OnNext(command);
+            return Task.CompletedTask;
+        }
+
+        public Task SendAsync(IEnumerable<TCommand> commands)
+        {
+            return Task.WhenAll(commands.Select(SendAsync));
+        }
+
+        public IObservable<TResponse> GetResponses(TRequest request)
+        {
+            if (_requestCorrelationProvider == null)
+            {
+                throw new InvalidOperationException("Please configure the SubjectServiceBus with a IRequestCorrelationProvider");
+            }
+
+            _requestCorrelationProvider.SetRequestCorrelationIds(request);
+
+            return Observable.Create<TResponse>(obs =>
+            {
+                var disposable = _responses
+                    .Where(r => _requestCorrelationProvider.AreCorrelated(request, r))
+                    .Subscribe(obs);
+                _requests.OnNext(request);
+                return disposable;
+            });
+        }
+
+        public IObservable<T> GetResponses<T>(TRequest request) where T : TResponse
+        {
+            return GetResponses(request).OfType<T>();
+        }
+
+        public IObservable<T> GetResponse<T>(TRequest request) where T : TResponse
+        {
+            return GetResponses(request).OfType<T>();
+        }
+
+        public Task PublishAsync(TEvent ev)
+        {
+            _events.OnNext(ev);
+            return Task.CompletedTask;
+        }
+
+        public Task ReplyAsync(TRequest request, TResponse response)
+        {
+            if (_requestCorrelationProvider == null)
+            {
+                throw new InvalidOperationException("Please configure the SubjectServiceBus with a IRequestCorrelationProvider");
+            }
+
+            _requestCorrelationProvider.SetCorrelationIds(request, response);
+
+            _responses.OnNext(response);
+
+            return Task.CompletedTask;
+        }
+
+        public IDisposable Subscribe(object subscriber, IScheduler scheduler = null)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Obvs/SubjectServiceBus.cs
+++ b/Obvs/SubjectServiceBus.cs
@@ -12,8 +12,8 @@ namespace Obvs
 {
     public class SubjectServiceBus : SubjectServiceBus<IMessage, ICommand, IEvent, IRequest, IResponse>, IServiceBus
     {
-        public SubjectServiceBus(IRequestCorrelationProvider requestCorrelationProvider) 
-            : base(requestCorrelationProvider)
+        public SubjectServiceBus(IRequestCorrelationProvider requestCorrelationProvider = null) 
+            : base(requestCorrelationProvider ?? new DefaultRequestCorrelationProvider())
         {
         }
 

--- a/Obvs/SubjectServiceBus.cs
+++ b/Obvs/SubjectServiceBus.cs
@@ -138,10 +138,5 @@ namespace Obvs
 
             return Task.CompletedTask;
         }
-
-        public IDisposable Subscribe(object subscriber, IScheduler scheduler = null)
-        {
-            throw new NotImplementedException();
-        }
     }
 }


### PR DESCRIPTION
These are breaking changes, so should probably be Obvs 6.0.

Are there any other breaking changes we should include?

I considered adding NoLocal to IEndpoint, so each transport extension could implement it, and then the ServiceBus would be able to tell which messages are safe to publish locally.